### PR TITLE
CST-391 Updated demos to autofill

### DIFF
--- a/Assets/ImmutableSDK/README.md
+++ b/Assets/ImmutableSDK/README.md
@@ -30,6 +30,10 @@ Alternatively, you can double click the Unity package file to open it and then f
 
 Three samples are provided to showcase some of the functionality such as fetching assets on IMX and getting user data.
 These examples can be found in `ImmutableSDK/Samples`.
+Demos use the below example wallets to auto fill that can be used for testing:
+0xF652A8bCb0Df65AE5fEd91DECaA8B591caeD1e1c
+0x5A7CB0ba4D94b6B08B837E4e97A90b9F2400C80D
+0x2d0ad946788938B9044ed72b1C464e1e9bb9d401
 
 ### 1. GetListedAssets
 This example shows how to fetch assets and apply filters to get results.
@@ -38,7 +42,7 @@ Load ListedAssets.unity as the active scene. If you do not have Text Mesh Pro se
 Some assets listed on IMX can use ascii characters not found in the font packs, to avoid Text Mesh Pro throwing warnings you can disable the `Disable warnings` flag in TMP settings scriptable object.
 The TMP settings by default is stored in `Assets/TextMesh Pro/Resources`
 
-Hit play and you should get an empty list with input fields and a FETCH button. Clicking the fetch button will fetch assets from immutable sandbox and display them in the list, this may take a few seconds to populate.
+Hit play and you should recieve pre populated inputs to view a Gods Unchained player wallet. Click fetch to view all the NFTs they own for that collection in their wallet.
 
 Below you can modify several query parameters to view assets on ImmutableX marketplace:
 Name will allow you to filter by NFT name.
@@ -52,7 +56,7 @@ This example shows how to fetch stark keys from a user wallet ID for operations.
 
 Load GetStarkKeys.unity and press play.
 
-You will receive an input field and fetch button, you will need to enter a user ID on IMX, click fetch and the user data field will populate with account keys for that user.
+You will receive an input field and fetch button alongside a pre-populated wallet address on main net. Press Get Stark Keys to view the L2 keys for this wallet.
 You have access to an environment toggle to fetch on sandbox or main net.
 
 ### 3. GetBalance
@@ -60,4 +64,4 @@ This example shows how to get the balances from a user wallet, and filter by tok
 
 Load GetBalance.unity and press play.
 
-You have a user wallet address input field for a public wallet key, and an environment dropdown if the balances are on sandbox or main net environments. Clicking Get Balance will return if a user has balances in that environment, and if so the token dropdown will populate with what tokens are in the wallet. Different tokens to view can be selected through the dropdown
+A user wallet will be pre-populated, clicking get balance will return their ETH balance on main net as wei.

--- a/Assets/ImmutableSDK/Samples/GetBalance/GetBalance.cs
+++ b/Assets/ImmutableSDK/Samples/GetBalance/GetBalance.cs
@@ -27,11 +27,16 @@ namespace ImmutableSDK.Samples.GetBalance
         private TMP_Text resultText = null;
     
         private List<Balance> userBalances = new List<Balance>();
+        
+        private const string defaultWalletAddress = "0x2d0ad946788938B9044ed72b1C464e1e9bb9d401"; // Default address for a wallet
 
         private void Awake()
         {
             // Update balance text whenever user changes token type
             tokenDropdown.onValueChanged.AddListener((T0) => DisplaySelectedBalance());
+
+            // Populate Defaults
+            ownerInput.text = defaultWalletAddress;
         }
 
         /// <summary>

--- a/Assets/ImmutableSDK/Samples/GetListedAssets/GetListedAssets.cs
+++ b/Assets/ImmutableSDK/Samples/GetListedAssets/GetListedAssets.cs
@@ -38,9 +38,16 @@ namespace ImmutableSDK.Samples.GetListedAssets
 
          private List<AssetListObject> listedAssets = new List<AssetListObject>();
 
+         private const string defaultCollectionAddress = "0x6ac5097f3fab829bae5462cb217133bc3c2a096e"; // Default address to a collection
+         private const string defaultWalletAddress = "0x5A7CB0ba4D94b6B08B837E4e97A90b9F2400C80D"; // Default address for a wallet
+
          private void Awake()
          {
              assetObj.gameObject.SetActive(false);
+             
+             // Populate defaults
+             collectionInput.text = defaultCollectionAddress;
+             userInput.text = defaultWalletAddress;
          }
 
          /// <summary>

--- a/Assets/ImmutableSDK/Samples/GetListedAssets/ListedAssets.unity
+++ b/Assets/ImmutableSDK/Samples/GetListedAssets/ListedAssets.unity
@@ -4781,7 +4781,7 @@ MonoBehaviour:
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_PressedColor: {r: 0.5943396, g: 0.5943396, b: 0.5943396, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
@@ -4798,7 +4798,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1165227127}
+  m_TargetGraphic: {fileID: 1591073251}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/ImmutableSDK/Samples/GetStarkKeys/GetUsersSample.cs
+++ b/Assets/ImmutableSDK/Samples/GetStarkKeys/GetUsersSample.cs
@@ -1,8 +1,10 @@
+using System;
 using Imx.Sdk;
 using Imx.Sdk.Gen.Client;
 using Imx.Sdk.Gen.Model;
 using TMPro;
 using UnityEngine;
+using Environment = Imx.Sdk.Environment;
 
 namespace ImmutableSDK.Samples.GetStarkKeys
 {
@@ -19,6 +21,14 @@ namespace ImmutableSDK.Samples.GetStarkKeys
         
         [SerializeField]
         private TMP_Dropdown environmentDropdown = null;
+        
+        private const string defaultWalletAddress = "0xF652A8bCb0Df65AE5fEd91DECaA8B591caeD1e1c"; // Default address for a wallet
+        
+        private void Awake()
+        {
+            // Populate Defaults
+            userInputField.text = defaultWalletAddress;
+        }
 
         /// <summary>
         /// Looks up a user via a UserID and returns account information containing Stark Keys


### PR DESCRIPTION
﻿# Summary

Demos updated to autofill input fields with test wallets to ease testing.

# Why the changes

Improve demos to not require external steps to be taken to prepare test accounts

# Things worth calling out

Scripts for each demo contain a test wallet that auto-fills on scene start for the input fields.
Readme updated to mention auto-filled fields and include the 3 testing addresses.
Unity scene change to have button highlight states on fetch button.
![PreFilledInputs3](https://user-images.githubusercontent.com/97069789/217701787-3b134ed1-4db1-42f1-b13f-8779561761a3.gif)

