### PR TITLE
CST-390: Ensure inspectors etc. loaded before window initialized

### DIFF
--- a/Assets/ImmutableSDK/Editor/EditorStartUp.cs
+++ b/Assets/ImmutableSDK/Editor/EditorStartUp.cs
@@ -8,15 +8,19 @@ namespace ImmutableSDK.Editor
     {
         static Startup()
         {
-            // Load the VSAttributionRegistration form state from EditorPrefs
-            var data = EditorPrefs.GetString(VSAttributionRegistration.GetEditorPrefsKey());
-            VSAttributionRegistration.VSAttributionRegistrationState vsRegState = new();
-            JsonUtility.FromJsonOverwrite(data, vsRegState);
-            // If the form has not been submitted, initialize and pop up the editor window if not already open
-            if (!vsRegState.submitted && !EditorWindow.HasOpenInstances<VSAttributionRegistration>())
+            // Wrap in a delay to ensure Unity inspectors etc. loaded so our window isn't destroyed
+            EditorApplication.delayCall += () =>
             {
-                VSAttributionRegistration.Initialize();
-            }
+                // Load the VSAttributionRegistration form state from EditorPrefs
+                var data = EditorPrefs.GetString(VSAttributionRegistration.GetEditorPrefsKey());
+                VSAttributionRegistration.VSAttributionRegistrationState vsRegState = new();
+                JsonUtility.FromJsonOverwrite(data, vsRegState);
+                // If the form has not been submitted, initialize and pop up the editor window if not already open
+                if (!vsRegState.submitted && !EditorWindow.HasOpenInstances<VSAttributionRegistration>())
+                {
+                    VSAttributionRegistration.Initialize();
+                }
+            };
         }
     }
 }

--- a/Assets/ImmutableSDK/Editor/VSAttributionRegistration.cs
+++ b/Assets/ImmutableSDK/Editor/VSAttributionRegistration.cs
@@ -20,14 +20,12 @@ namespace ImmutableSDK.Editor
 
         protected void OnEnable()
         {
-            Debug.Log("OnEnable");
             // Retrieve existing data if already registered to prevent sending multiple events
             LoadVSRegState();
         }
 
         protected void OnDestroy()
         {
-            Debug.Log("OnDestroy");
             // Save entered data on exit
             SaveVSRegState();
         }
@@ -113,7 +111,6 @@ namespace ImmutableSDK.Editor
         /// <returns>A unique project key used for form state storage in EditorPrefs</returns>
         public static string GetEditorPrefsKey()
         {
-            Debug.Log("GetEditorPrefsKey");
             string productGuid = PlayerSettings.productGUID != null ? PlayerSettings.productGUID.ToString() : "";
             return "ImxVSRegAttr-" + PRODUCT_VERSION + "-" + productGuid;
         }


### PR DESCRIPTION
﻿# Summary

A small change to ensure the window isn't accidentally initialized and destroyed before unity is finished loading.

# Before merging

- [ ] **_For Immutable developers:_** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] _Add documentation update 1_
    - [ ] _Add documentation update 2_