### PR TITLE
[DX-2500]: Add CODEOWNERS and deprecation banner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @immutable/sdk

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
   </p>
 </div>
 
+# 🚨 This library is no longer maintained 🚨
+
+If you're building apps with Immutable, please use [Immutable's Unified SDK](https://github.com/immutable/ts-immutable-sdk)
+
 # Immutable Unity SDK
 The Immutable Unity SDK package provides access to ImmutableX API endpoints from within Unity projects using the Immutable Core SDK C#.
 


### PR DESCRIPTION
﻿# Summary

Add CODEOWNERS and deprecation banner

# Why the changes

To ensure this repository has a valid code owner and to point users to the new Unified SDK

# Things worth calling out

No code changes

# Before merging

- [x] **_For Immutable developers:_** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] _Add documentation update 1_
    - [ ] _Add documentation update 2_